### PR TITLE
Fixed help formatting

### DIFF
--- a/example.py
+++ b/example.py
@@ -167,7 +167,7 @@ For CockroachCloud Free, use
 
 If you are using the connection string copied from the Console, your username,
 password, and cluster name will be pre-populated. Replace
-<your_certs_directory> with the path to the cc-ca.cert downloaded from the
+<your_certs_directory> with the path to the 'cc-ca.crt' downloaded from the
 Console.
 
 """

--- a/example.py
+++ b/example.py
@@ -153,13 +153,24 @@ def parse_cmdline():
                             formatter_class=RawTextHelpFormatter)
     parser.add_argument(
         "dsn",
-        help="""database connection string\n\n
-             For cockroach demo, use 'postgresql://<username>:<password>@<hostname>:<port>/bank?sslmode=require',\n
-             with the username and password created in the demo cluster, and the hostname and port listed in the\n
-             (sql/tcp) connection parameters of the demo cluster welcome message.\n\n
-             For CockroachCloud Free, use 'postgres://<username>:<password>@free-tier.gcp-us-central1.cockroachlabs.cloud:26257/<cluster-name>.bank?sslmode=verify-full&sslrootcert=<your_certs_directory>/cc-ca.crt'.\n
-             If you are using the connection string copied from the Console, your username, password, and cluster name will be pre-populated.\n
-             Replace <your_certs_directory> with the path to the cc-ca.cert downloaded from the Console."""
+        help="""\
+database connection string
+
+For cockroach demo, use
+'postgresql://<username>:<password>@<hostname>:<port>/bank?sslmode=require',
+with the username and password created in the demo cluster, and the hostname
+and port listed in the (sql/tcp) connection parameters of the demo cluster
+welcome message.
+
+For CockroachCloud Free, use
+'postgres://<username>:<password>@free-tier.gcp-us-central1.cockroachlabs.cloud:26257/<cluster-name>.bank?sslmode=verify-full&sslrootcert=<your_certs_directory>/cc-ca.crt'.
+
+If you are using the connection string copied from the Console, your username,
+password, and cluster name will be pre-populated. Replace
+<your_certs_directory> with the path to the cc-ca.cert downloaded from the
+Console.
+
+"""
     )
 
     parser.add_argument("-v", "--verbose",


### PR DESCRIPTION
Fix the script help to display from:
```
(.venv) piro@baloo:~/dev/hello-world-python-psycopg2$ python3 example.py --help
usage: example.py [-h] [-v] dsn

Test psycopg with CockroachDB.

positional arguments:
  dsn            database connection string
                 
                 
                              For cockroach demo, use 'postgresql://<username>:<password>@<hostname>:<port>/bank?sslmode=require',
                 
                              with the username and password created in the demo cluster, and the hostname and port listed in the
                 
                              (sql/tcp) connection parameters of the demo cluster welcome message.
                 
                 
                              For CockroachCloud Free, use 'postgres://<username>:<password>@free-tier.gcp-us-central1.cockroachlabs.cloud:26257/<cluster-name>.bank?sslmode=verify-full&sslrootcert=<your_certs_directory>/cc-ca.crt'.
                 
                              If you are using the connection string copied from the Console, your username, password, and cluster name will be pre-populated.
                 
                              Replace <your_certs_directory> with the path to the cc-ca.cert downloaded from the Console.

optional arguments:
  -h, --help     show this help message and exit
  -v, --verbose  print debug info
```

to 

```
positional arguments:
  dsn            database connection string
                 
                 For cockroach demo, use
                 'postgresql://<username>:<password>@<hostname>:<port>/bank?sslmode=require',
                 with the username and password created in the demo cluster, and the hostname
                 and port listed in the (sql/tcp) connection parameters of the demo cluster
                 welcome message.
                 
                 For CockroachCloud Free, use
                 'postgres://<username>:<password>@free-tier.gcp-us-central1.cockroachlabs.cloud:26257/<cluster-name>.bank?sslmode=verify-full&sslrootcert=<your_certs_directory>/cc-ca.crt'.
                 
                 If you are using the connection string copied from the Console, your username,
                 password, and cluster name will be pre-populated. Replace
                 <your_certs_directory> with the path to the cc-ca.cert downloaded from the
                 Console.
                 

optional arguments:
```

The url is still unwieldy though... 