### PR TITLE
Add application_name parameter to the Python connection string

### DIFF
--- a/example.py
+++ b/example.py
@@ -27,7 +27,7 @@ def create_accounts(conn):
 
 def delete_accounts(conn):
     with conn.cursor() as cur:
-        cur.execute("DELETE FROM bank.accounts")
+        cur.execute("DELETE FROM accounts")
         logging.debug("delete_accounts(): status message: %s",
                       cur.statusmessage)
     conn.commit()

--- a/example.py
+++ b/example.py
@@ -118,7 +118,7 @@ def main():
         # For information on supported connection string formats, see
         # https://www.cockroachlabs.com/docs/stable/connect-to-the-database.html.
         db_url = opt.dsn
-        conn = psycopg2.connect(db_url)
+        conn = psycopg2.connect(db_url, application_name="$ docs_simplecrud_psycopg2")
     except Exception as e:
         logging.fatal("database connection failed")
         logging.fatal(e)


### PR DESCRIPTION
This will help us more accurately identify docs-attributed
Serverless clusters and their usage over time.

Part of DOC-4617.

Also fix the delete statement, which was referencing a 
a non-existent "bank" database.