### PR TITLE
Changing PK to UUID, improving formatting.

### DIFF
--- a/example.py
+++ b/example.py
@@ -17,15 +17,21 @@ import psycopg2.extras
 
 def create_accounts(conn):
     psycopg2.extras.register_uuid()
+    ids = []
+    id1 = uuid.uuid4()
+    id2 = uuid.uuid4()
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(
             "CREATE TABLE IF NOT EXISTS accounts (id UUID PRIMARY KEY, balance INT)"
         )
         cur.execute(
-            "UPSERT INTO accounts (id, balance) VALUES (%s, 1000), (%s, 250)", (uuid.uuid4(), uuid.uuid4()))
+            "UPSERT INTO accounts (id, balance) VALUES (%s, 1000), (%s, 250)", (id1, id2))
         logging.debug("create_accounts(): status message: %s",
                       cur.statusmessage)
     conn.commit()
+    ids.append(id1)
+    ids.append(id2)
+    return ids
 
 
 def delete_accounts(conn):
@@ -43,12 +49,9 @@ def print_balances(conn):
                       cur.statusmessage)
         rows = cur.fetchall()
         conn.commit()
-        ids = []
         print(f"Balances at {time.asctime()}:")
         for row in rows:
             print("account id: {0}  balance: ${1:2d}".format(row['id'], row['balance']))
-            ids.append(row['id'])
-        return ids
 
 
 def transfer_funds(conn, frm, to, amount):
@@ -129,8 +132,8 @@ def main():
         logging.fatal("database connection failed")
         logging.fatal(e)
         return
-    create_accounts(conn)
-    ids = print_balances(conn)
+    ids = create_accounts(conn)
+    print_balances(conn)
 
     amount = 100
     toId = ids.pop()

--- a/example.py
+++ b/example.py
@@ -20,7 +20,7 @@ def create_accounts(conn):
     ids = []
     id1 = uuid.uuid4()
     id2 = uuid.uuid4()
-    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+    with conn.cursor() as cur:
         cur.execute(
             "CREATE TABLE IF NOT EXISTS accounts (id UUID PRIMARY KEY, balance INT)"
         )
@@ -35,7 +35,7 @@ def create_accounts(conn):
 
 
 def delete_accounts(conn):
-    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+    with conn.cursor() as cur:
         cur.execute("DELETE FROM accounts")
         logging.debug("delete_accounts(): status message: %s",
                       cur.statusmessage)
@@ -43,7 +43,7 @@ def delete_accounts(conn):
 
 
 def print_balances(conn):
-    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+    with conn.cursor() as cur:
         cur.execute("SELECT id, balance FROM accounts")
         logging.debug("print_balances(): status message: %s",
                       cur.statusmessage)
@@ -59,7 +59,7 @@ def transfer_funds(conn, frm, to, amount):
 
         # Check the current balance.
         cur.execute("SELECT balance FROM accounts WHERE id = %s", (frm,))
-        from_balance = cur.fetchone()[0]
+        from_balance = cur.fetchone()['balance']
         if from_balance < amount:
             raise RuntimeError(
                 f"insufficient funds in {frm}: have {from_balance}, need {amount}"
@@ -127,7 +127,9 @@ def main():
         # For information on supported connection string formats, see
         # https://www.cockroachlabs.com/docs/stable/connect-to-the-database.html.
         db_url = opt.dsn
-        conn = psycopg2.connect(db_url, application_name="$ docs_simplecrud_psycopg2")
+        conn = psycopg2.connect(db_url, 
+                                application_name="$ docs_simplecrud_psycopg2", 
+                                cursor_factory=psycopg2.extras.RealDictCursor)
     except Exception as e:
         logging.fatal("database connection failed")
         logging.fatal(e)


### PR DESCRIPTION
This PR aligns the example with the other simple CRUD examples in using UUID as the primary key type. It also improves the formatting of the printed rows.